### PR TITLE
listSessions Demo Use Cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@radix-ui/themes": "^3.1.6",
         "@tanstack/react-query": "^5.62.11",
         "@workos-inc/authkit-nextjs": "^2.2.0",
-        "@workos-inc/node": "^7.45.0",
+        "@workos-inc/node": "^7.62.0",
         "@workos-inc/widgets": "^1.1.5",
         "jwt-decode": "^4.0.0",
         "next": "^15.0.1",
@@ -5139,15 +5139,16 @@
       }
     },
     "node_modules/@workos-inc/node": {
-      "version": "7.45.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-7.45.0.tgz",
-      "integrity": "sha512-8wx2YuhkmTc3bKc1Py/Gv8X44QovIDQVLfDL8qNMRybCLD5Cu7R6AnWP/ZI5VHwSgeird0g+Cuukqk3ZG8ycMg==",
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-7.62.0.tgz",
+      "integrity": "sha512-KrenK9jbZW1/Gv17jBWPbbqVT9XZYf5YMM8UTlSqbj2hw87MJOO3idmwV4M/6eP9aXRfizjNrSrLkSfWWkLeaA==",
       "license": "MIT",
       "dependencies": {
         "iron-session": "~6.3.1",
         "jose": "~5.6.3",
         "leb": "^1.0.0",
-        "pluralize": "8.0.0"
+        "pluralize": "8.0.0",
+        "qs": "6.14.0"
       },
       "engines": {
         "node": ">=16"
@@ -5896,6 +5897,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-me-maybe": {
@@ -9272,10 +9289,10 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-      "dev": true,
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -9870,6 +9887,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -10882,15 +10914,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@radix-ui/themes": "^3.1.6",
     "@tanstack/react-query": "^5.62.11",
     "@workos-inc/authkit-nextjs": "^2.2.0",
-    "@workos-inc/node": "^7.45.0",
+    "@workos-inc/node": "^7.62.0",
     "@workos-inc/widgets": "^1.1.5",
     "jwt-decode": "^4.0.0",
     "next": "^15.0.1",

--- a/src/app/api/get-name/route.ts
+++ b/src/app/api/get-name/route.ts
@@ -1,13 +1,16 @@
-import { getSession } from "@workos-inc/authkit-nextjs";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { NextResponse } from "next/server";
 
 export const GET = async () => {
-  // Use 'getSession' for edge functions that don't have access to headers
-  const session = await getSession();
+  try {
+    const { user } = await withAuth();
+    
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
 
-  if (!session || !session.user) {
-    return NextResponse.json({ error: "User not found" }, { status: 404 });
+    return NextResponse.json({ name: user.firstName });
+  } catch (error) {
+    return NextResponse.json({ error: "Authentication failed" }, { status: 401 });
   }
-
-  return NextResponse.json({ name: session.user.firstName });
 };

--- a/src/app/api/list-organization-users/route.ts
+++ b/src/app/api/list-organization-users/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { workos } from "../../workos";
+
+export async function GET() {
+  try {
+    const { role, organizationId } = await withAuth({
+      ensureSignedIn: true,
+    });
+
+    if (role !== "admin") {
+      return NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const memberships = await workos.userManagement.listOrganizationMemberships({
+      organizationId,
+    });
+
+    // Fetch full user details for each membership
+    const usersWithDetails = await Promise.all(
+      memberships.data.map(async (membership) => {
+        try {
+          const userDetails = await workos.userManagement.getUser(membership.userId);
+          return {
+            ...membership,
+            user: {
+              id: userDetails.id,
+              email: userDetails.email,
+              firstName: userDetails.firstName,
+              lastName: userDetails.lastName,
+            }
+          };
+        } catch (error) {
+          console.error(`Failed to fetch details for user ${membership.userId}:`, error);
+          // Return membership with minimal user info if getUser fails
+          return {
+            ...membership,
+            user: {
+              id: membership.userId,
+              email: membership.userId, // fallback
+              firstName: null,
+              lastName: null,
+            }
+          };
+        }
+      })
+    );
+
+    return NextResponse.json({
+      users: usersWithDetails,
+      metadata: {
+        listMetadata: memberships.listMetadata,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching organization users:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch organization users" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/list-sessions/route.ts
+++ b/src/app/api/list-sessions/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { workos } from "../../workos";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { user, organizationId } = await withAuth({
+      ensureSignedIn: true,
+    });
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const sessions = await workos.userManagement.listSessions(
+      user.id,
+    );
+
+    return NextResponse.json({
+      sessions: sessions.data,
+      metadata: {
+        listMetadata: sessions.listMetadata,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching user sessions:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch sessions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/list-user-sessions/route.ts
+++ b/src/app/api/list-user-sessions/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { workos } from "../../workos";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { role, organizationId } = await withAuth({
+      ensureSignedIn: true,
+    });
+
+    if (role !== "admin") {
+      return NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: "User ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const sessions = await workos.userManagement.listSessions(userId);
+    
+    // Get user details to include name information
+    const user = await workos.userManagement.getUser(userId);
+    
+    // Enhance sessions with user information
+    const sessionsWithUser = sessions.data.map(session => ({
+      ...session,
+      user: {
+        id: user.id,
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+      }
+    }));
+
+    return NextResponse.json({
+      sessions: sessionsWithUser,
+      metadata: {
+        listMetadata: sessions.listMetadata,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching user sessions:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch user sessions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/revoke-all-user-sessions/route.ts
+++ b/src/app/api/revoke-all-user-sessions/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, signOut } from "@workos-inc/authkit-nextjs";
+import { workos } from "../../workos";
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { role, organizationId, user, sessionId } = await withAuth({
+      ensureSignedIn: true,
+    });
+
+    if (role !== "admin") {
+      return NextResponse.json(
+        { error: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: "User ID is required" },
+        { status: 400 }
+      );
+    }
+
+    // Check if the current user is trying to revoke their own sessions
+    const isCurrentUser = userId === user.id;
+
+    // First get all sessions for the user
+    const userSessions = await workos.userManagement.listSessions(userId);
+    
+    // Revoke each session
+    const revokePromises = userSessions.data.map(session =>
+      workos.userManagement.revokeSession({ sessionId: session.id })
+    );
+
+    await Promise.all(revokePromises);
+
+    // If the current user revoked their own sessions, sign them out using WorkOS SDK
+    if (isCurrentUser) {
+      await signOut();
+      return NextResponse.json({
+        success: true,
+        message: `Successfully revoked ${userSessions.data.length} session(s)`,
+        revokedCount: userSessions.data.length,
+        shouldLogout: true,
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `Successfully revoked ${userSessions.data.length} session(s)`,
+      revokedCount: userSessions.data.length,
+      shouldLogout: false,
+    });
+  } catch (error) {
+    console.error("Error revoking all user sessions:", error);
+    return NextResponse.json(
+      { error: "Failed to revoke all user sessions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/revoke-session/route.ts
+++ b/src/app/api/revoke-session/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { workos } from "../../workos";
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { user, organizationId } = await withAuth({
+      ensureSignedIn: true,
+    });
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const sessionId = searchParams.get("sessionId");
+
+    if (!sessionId) {
+      return NextResponse.json(
+        { error: "Session ID is required" },
+        { status: 400 }
+      );
+    }
+
+    await workos.userManagement.revokeSession({
+      sessionId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Session revoked successfully",
+    });
+  } catch (error) {
+    console.error("Error revoking session:", error);
+    return NextResponse.json(
+      { error: "Failed to revoke session" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/SignInButton.tsx
+++ b/src/app/components/SignInButton.tsx
@@ -2,7 +2,7 @@ import { getSignInUrl, withAuth, signOut } from "@workos-inc/authkit-nextjs";
 import { Button, Flex } from "@radix-ui/themes";
 
 export async function SignInButton({ large }: { large?: boolean }) {
-  const { user } = await withAuth();
+  const { user } = await withAuth({ ensureSignedIn: false });
   const authorizationUrl = await getSignInUrl();
 
   if (user) {

--- a/src/app/components/TeamUserSessions.tsx
+++ b/src/app/components/TeamUserSessions.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Flex, Text, Card, Badge, Button, Separator } from "@radix-ui/themes";
+import { 
+  PersonIcon, 
+  TrashIcon, 
+  ChevronDownIcon, 
+  ChevronRightIcon,
+  CalendarIcon,
+  GlobeIcon,
+  DesktopIcon
+} from "@radix-ui/react-icons";
+
+interface User {
+  id: string;
+  userId: string;
+  organizationId: string;
+  status: string;
+  role: string | { slug: string };
+  createdAt: string;
+  updatedAt: string;
+  user: {
+    id: string;
+    email: string;
+    firstName?: string;
+    lastName?: string;
+  };
+}
+
+interface Session {
+  id: string;
+  userId: string;
+  organizationId: string;
+  createdAt: string;
+  updatedAt: string;
+  ipAddress?: string;
+  userAgent?: string;
+  user?: {
+    id: string;
+    email: string;
+    firstName?: string;
+    lastName?: string;
+  };
+}
+
+interface UserWithSessions extends User {
+  sessions: Session[];
+  sessionsLoading: boolean;
+  sessionsExpanded: boolean;
+}
+
+interface TeamUserSessionsProps {
+  currentUserId?: string;
+  currentSessionId?: string;
+}
+
+export function TeamUserSessions({ currentUserId, currentSessionId }: TeamUserSessionsProps = {}) {
+  const [users, setUsers] = useState<UserWithSessions[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingUserId, setRevokingUserId] = useState<string | null>(null);
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/list-organization-users");
+      if (!response.ok) {
+        throw new Error("Failed to fetch organization users");
+      }
+      const data = await response.json();
+      const usersWithSessions: UserWithSessions[] = data.users
+        .map((user: User) => ({
+          ...user,
+          sessions: [],
+          sessionsLoading: false,
+          sessionsExpanded: false,
+        }))
+        .sort((a, b) => {
+          // Sort by name if available, otherwise by email
+          const aName = a.user?.firstName && a.user?.lastName 
+            ? `${a.user.firstName} ${a.user.lastName}` 
+            : a.user?.email || a.userId;
+          const bName = b.user?.firstName && b.user?.lastName 
+            ? `${b.user.firstName} ${b.user.lastName}` 
+            : b.user?.email || b.userId;
+          return aName.localeCompare(bName);
+        });
+      setUsers(usersWithSessions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchUserSessions = async (userId: string) => {
+    setUsers(prev => prev.map(user => 
+      user.userId === userId 
+        ? { ...user, sessionsLoading: true } 
+        : user
+    ));
+
+    try {
+      const response = await fetch(`/api/list-user-sessions?userId=${userId}`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch user sessions");
+      }
+      const data = await response.json();
+      
+      setUsers(prev => prev.map(user => 
+        user.userId === userId 
+          ? { ...user, sessions: data.sessions, sessionsLoading: false, sessionsExpanded: true }
+          : user
+      ));
+    } catch (err) {
+      setUsers(prev => prev.map(user => 
+        user.userId === userId 
+          ? { ...user, sessionsLoading: false }
+          : user
+      ));
+      setError("Failed to fetch user sessions");
+    }
+  };
+
+  const revokeAllUserSessions = async (userId: string) => {
+    setRevokingUserId(userId);
+    try {
+      const response = await fetch(`/api/revoke-all-user-sessions?userId=${userId}`, {
+        method: "DELETE",
+      });
+      
+      if (!response.ok) {
+        throw new Error("Failed to revoke all user sessions");
+      }
+      
+      const data = await response.json();
+      
+      // If the API indicates the user should be logged out
+      if (data.shouldLogout) {
+        // Force a full page reload to clear any cached auth state
+        window.location.href = "/api/auth/logout";
+        return;
+      }
+      
+      // Refresh sessions for this user
+      await fetchUserSessions(userId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to revoke sessions");
+    } finally {
+      setRevokingUserId(null);
+    }
+  };
+
+  const toggleUserSessions = async (userId: string) => {
+    const user = users.find(u => u.userId === userId);
+    if (!user) return;
+
+    if (user.sessionsExpanded) {
+      setUsers(prev => prev.map(u => 
+        u.userId === userId 
+          ? { ...u, sessionsExpanded: false }
+          : u
+      ));
+    } else {
+      await fetchUserSessions(userId);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  const getBrowserFromUserAgent = (userAgent?: string) => {
+    if (!userAgent) return "Unknown";
+    if (userAgent.includes("Chrome")) return "Chrome";
+    if (userAgent.includes("Firefox")) return "Firefox";
+    if (userAgent.includes("Safari")) return "Safari";
+    if (userAgent.includes("Edge")) return "Edge";
+    return "Other";
+  };
+
+  const getOSFromUserAgent = (userAgent?: string) => {
+    if (!userAgent) return "Unknown";
+    if (userAgent.includes("Windows")) return "Windows";
+    if (userAgent.includes("Mac")) return "macOS";
+    if (userAgent.includes("Linux")) return "Linux";
+    if (userAgent.includes("Android")) return "Android";
+    if (userAgent.includes("iOS")) return "iOS";
+    return "Other";
+  };
+
+  const getUserDisplayName = (user: User) => {
+    // Always show name if available, otherwise show email
+    if (user.user?.firstName && user.user?.lastName) {
+      return `${user.user.firstName} ${user.user.lastName}`;
+    }
+    // Should always have email from organization membership data
+    return user.user?.email || 'Unknown User';
+  };
+
+  const getUserSubtitle = (user: User) => {
+    const role = typeof user.role === 'object' ? user.role?.slug || 'Unknown Role' : user.role;
+    
+    // If we have a name, show email + role in subtitle
+    // If we only have email, just show role in subtitle
+    if (user.user?.firstName && user.user?.lastName && user.user?.email) {
+      return `${user.user.email} • ${role}`;
+    }
+    
+    // If we're showing email as the display name, just show role
+    return role;
+  };
+
+  const getSessionDisplayName = (session: Session) => {
+    if (session.user?.firstName && session.user?.lastName) {
+      return `${session.user.firstName} ${session.user.lastName}`;
+    }
+    return session.user?.email || `Session ${session.id.slice(-8)}`;
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  if (loading) {
+    return (
+      <Flex direction="column" gap="3">
+        <Text size="3" color="gray">
+          Loading team users...
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (error) {
+    return (
+      <Flex direction="column" gap="3">
+        <Text size="3" color="red">
+          Error: {error}
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (users.length === 0) {
+    return (
+      <Flex direction="column" gap="3">
+        <Text size="3" color="gray">
+          No team members found.
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="4">
+      <Text size="3" color="gray">
+        Manage sessions for all team members. Admins can view and revoke sessions for any user.
+      </Text>
+      
+      <Text size="4" weight="bold">
+        Team Member Sessions ({users.length} users)
+      </Text>
+
+      <Flex direction="column" gap="3">
+        {users.map((user) => (
+          <Card key={user.userId} style={{ padding: "16px" }}>
+            <Flex direction="column" gap="3">
+              <Flex justify="between" align="center">
+                <Flex align="center" gap="2">
+                  <PersonIcon />
+                  <Flex direction="column" gap="1">
+                    <Text size="3" weight="bold">
+                      {getUserDisplayName(user)}
+                      {user.userId === currentUserId && (
+                        <Badge color="blue" variant="soft" size="1" style={{ marginLeft: "8px" }}>
+                          You
+                        </Badge>
+                      )}
+                    </Text>
+                    <Text size="2" color="gray">
+                      {getUserSubtitle(user)}
+                    </Text>
+                  </Flex>
+                </Flex>
+                <Flex align="center" gap="2">
+                  <Badge 
+                    color={user.status === "active" ? "green" : "gray"} 
+                    variant="soft"
+                  >
+                    {user.status}
+                  </Badge>
+                  <Button
+                    size="1"
+                    variant="soft"
+                    onClick={() => toggleUserSessions(user.userId)}
+                    disabled={user.sessionsLoading}
+                  >
+                    {user.sessionsLoading ? (
+                      "Loading..."
+                    ) : (
+                      <>
+                        {user.sessionsExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                        {user.sessionsExpanded ? "Hide" : "Show"} Sessions
+                      </>
+                    )}
+                  </Button>
+                  {user.sessions.length > 0 && (
+                    <Button
+                      size="1"
+                      color="red"
+                      variant="soft"
+                      onClick={() => revokeAllUserSessions(user.userId)}
+                      disabled={revokingUserId === user.userId}
+                    >
+                      {revokingUserId === user.userId ? (
+                        "Revoking..."
+                      ) : (
+                        <>
+                          <TrashIcon width="12" height="12" />
+                          Revoke All Sessions
+                        </>
+                      )}
+                    </Button>
+                  )}
+                </Flex>
+              </Flex>
+
+              {user.sessionsExpanded && (
+                <Flex direction="column" gap="2" style={{ marginTop: "12px" }}>
+                  <Separator />
+                  {user.sessions.length === 0 ? (
+                    <Text size="2" color="gray" style={{ padding: "8px 0" }}>
+                      No active sessions
+                    </Text>
+                  ) : (
+                    <Flex direction="column" gap="2">
+                      <Text size="2" weight="medium" color="gray">
+                        Active Sessions ({user.sessions.length})
+                      </Text>
+                      {user.sessions.map((session) => (
+                        <Card key={session.id} style={{ padding: "12px", backgroundColor: "var(--gray-1)" }}>
+                          <Flex direction="column" gap="2">
+                            <Flex justify="between" align="center">
+                              <Flex align="center" gap="2">
+                                <DesktopIcon width="14" height="14" />
+                                <Text size="2" weight="medium">
+                                  {getSessionDisplayName(session)}
+                                </Text>
+                              </Flex>
+                              <Badge color="green" variant="soft" size="1">
+                                Active
+                              </Badge>
+                            </Flex>
+                            
+                            <Flex direction="column" gap="1">
+                              <Flex align="center" gap="2">
+                                <CalendarIcon width="12" height="12" />
+                                <Text size="1" color="gray">
+                                  Created: {formatDate(session.createdAt)}
+                                </Text>
+                              </Flex>
+                              {session.ipAddress && (
+                                <Flex align="center" gap="2">
+                                  <GlobeIcon width="12" height="12" />
+                                  <Text size="1" color="gray">
+                                    IP: {session.ipAddress}
+                                  </Text>
+                                </Flex>
+                              )}
+                              {session.userAgent && (
+                                <Flex gap="1">
+                                  <Badge color="blue" variant="soft" size="1">
+                                    {getBrowserFromUserAgent(session.userAgent)}
+                                  </Badge>
+                                  <Badge color="purple" variant="soft" size="1">
+                                    {getOSFromUserAgent(session.userAgent)}
+                                  </Badge>
+                                </Flex>
+                              )}
+                            </Flex>
+                          </Flex>
+                        </Card>
+                      ))}
+                    </Flex>
+                  )}
+                </Flex>
+              )}
+            </Flex>
+          </Card>
+        ))}
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/app/components/UserSessionsList.tsx
+++ b/src/app/components/UserSessionsList.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Flex, Text, Card, Badge, Separator, Button } from "@radix-ui/themes";
+import { CalendarIcon, GlobeIcon, DesktopIcon, TrashIcon } from "@radix-ui/react-icons";
+
+interface Session {
+  id: string;
+  userId: string;
+  organizationId: string;
+  createdAt: string;
+  updatedAt: string;
+  ipAddress?: string;
+  userAgent?: string;
+  object: string;
+}
+
+interface SessionsData {
+  sessions: Session[];
+  metadata: {
+    listMetadata: {
+      before?: string;
+      after?: string;
+    };
+  };
+}
+
+export function UserSessionsList() {
+  const [sessionsData, setSessionsData] = useState<SessionsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingSessionId, setRevokingSessionId] = useState<string | null>(null);
+
+  const fetchSessions = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/list-sessions");
+      if (!response.ok) {
+        throw new Error("Failed to fetch sessions");
+      }
+      const data = await response.json();
+      setSessionsData(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const revokeSession = async (sessionId: string) => {
+    setRevokingSessionId(sessionId);
+    try {
+      const response = await fetch(`/api/revoke-session?sessionId=${sessionId}`, {
+        method: "DELETE",
+      });
+      
+      if (!response.ok) {
+        throw new Error("Failed to revoke session");
+      }
+      
+      // Refresh the sessions list after successful revocation
+      await fetchSessions();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to revoke session");
+    } finally {
+      setRevokingSessionId(null);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessions();
+  }, []);
+
+  if (loading) {
+    return (
+      <Flex direction="column" gap="3">
+        <Text size="3" color="gray">
+          Loading user sessions...
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (error) {
+    return (
+      <Flex direction="column" gap="3">
+        <Text size="3" color="red">
+          Error: {error}
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (!sessionsData || sessionsData.sessions.length === 0) {
+    return (
+      <Flex direction="column" gap="3">
+        <Text size="3" color="gray">
+          No active sessions found.
+        </Text>
+      </Flex>
+    );
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  const getBrowserFromUserAgent = (userAgent?: string) => {
+    if (!userAgent) return "Unknown";
+    if (userAgent.includes("Chrome")) return "Chrome";
+    if (userAgent.includes("Firefox")) return "Firefox";
+    if (userAgent.includes("Safari")) return "Safari";
+    if (userAgent.includes("Edge")) return "Edge";
+    return "Other";
+  };
+
+  const getOSFromUserAgent = (userAgent?: string) => {
+    if (!userAgent) return "Unknown";
+    if (userAgent.includes("Windows")) return "Windows";
+    if (userAgent.includes("Mac")) return "macOS";
+    if (userAgent.includes("Linux")) return "Linux";
+    if (userAgent.includes("Android")) return "Android";
+    if (userAgent.includes("iOS")) return "iOS";
+    return "Other";
+  };
+
+  return (
+    <Flex direction="column" gap="4">
+      <Text size="3" color="gray">
+        Active user sessions retrieved via WorkOS userManagement.listSessions API
+      </Text>
+      
+      <Text size="4" weight="bold">
+        Sessions ({sessionsData.sessions.length})
+      </Text>
+
+      <Flex direction="column" gap="3">
+        {sessionsData.sessions.map((session) => (
+          <Card key={session.id} style={{ padding: "16px" }}>
+            <Flex direction="column" gap="3">
+              <Flex justify="between" align="center">
+                <Flex align="center" gap="2">
+                  <DesktopIcon />
+                  <Text size="3" weight="bold">
+                    Session {session.id.slice(-8)}
+                  </Text>
+                </Flex>
+                <Flex align="center" gap="2">
+                  <Badge color="green" variant="soft">
+                    Active
+                  </Badge>
+                  <Button
+                    size="1"
+                    color="red"
+                    variant="soft"
+                    onClick={() => revokeSession(session.id)}
+                    disabled={revokingSessionId === session.id}
+                  >
+                    {revokingSessionId === session.id ? (
+                      "Revoking..."
+                    ) : (
+                      <>
+                        <TrashIcon width="12" height="12" />
+                        Revoke
+                      </>
+                    )}
+                  </Button>
+                </Flex>
+              </Flex>
+
+              <Flex direction="column" gap="2">
+                <Flex align="center" gap="2">
+                  <CalendarIcon width="14" height="14" />
+                  <Text size="2" color="gray">
+                    Created: {formatDate(session.createdAt)}
+                  </Text>
+                </Flex>
+                <Flex align="center" gap="2">
+                  <CalendarIcon width="14" height="14" />
+                  <Text size="2" color="gray">
+                    Updated: {formatDate(session.updatedAt)}
+                  </Text>
+                </Flex>
+                {session.ipAddress && (
+                  <Flex align="center" gap="2">
+                    <GlobeIcon width="14" height="14" />
+                    <Text size="2" color="gray">
+                      IP: {session.ipAddress}
+                    </Text>
+                  </Flex>
+                )}
+              </Flex>
+
+              {session.userAgent && (
+                <Flex direction="column" gap="1">
+                  <Text size="2" weight="medium">
+                    Device Info:
+                  </Text>
+                  <Flex gap="2">
+                    <Badge color="blue" variant="soft">
+                      {getBrowserFromUserAgent(session.userAgent)}
+                    </Badge>
+                    <Badge color="purple" variant="soft">
+                      {getOSFromUserAgent(session.userAgent)}
+                    </Badge>
+                  </Flex>
+                  <Text size="1" color="gray" style={{ maxWidth: "100%", wordBreak: "break-all" }}>
+                    {session.userAgent}
+                  </Text>
+                </Flex>
+              )}
+            </Flex>
+          </Card>
+        ))}
+      </Flex>
+
+      <Separator />
+
+      <Flex direction="column" gap="3">
+        <Text size="4" weight="bold">
+          Raw API Response
+        </Text>
+        <Text size="2" color="gray">
+          Complete response from WorkOS userManagement.listSessions()
+        </Text>
+        <pre
+          style={{
+            backgroundColor: "var(--gray-2)",
+            padding: "16px",
+            borderRadius: "var(--radius-3)",
+            border: "1px solid var(--gray-5)",
+            overflow: "auto",
+            fontSize: "11px",
+            lineHeight: "1.4",
+            maxHeight: "400px",
+          }}
+        >
+          {JSON.stringify(sessionsData, null, 2)}
+        </pre>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,10 @@
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import type { NextRequest, NextFetchEvent } from "next/server";
 
 // Create a custom middleware that wraps the authkit middleware
-async function customMiddleware(request: NextRequest) {
-  const response = await authkitMiddleware()(request, NextResponse.next());
+async function customMiddleware(request: NextRequest, event: NextFetchEvent) {
+  const response = await authkitMiddleware()(request, event);
 
   if (response) {
     // Log the session data from the response headers
@@ -28,16 +28,16 @@ async function customMiddleware(request: NextRequest) {
 
 export default customMiddleware;
 
-// Match against the pages
+// Match against ALL pages - AuthKit middleware must run on all routes where withAuth is called
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
+     * Match ALL request paths except for the ones starting with:
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
-     * - public folder
+     * Include API routes so withAuth works everywhere
      */
-    "/((?!_next/static|_next/image|favicon.ico|public/).*)",
+    "/((?!_next/static|_next/image|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
 - New Sessions API tab with detailed session list/payload
      - Shows a way for users to see their sessions without needing widget
 - Added session listing and revocation in team member management tab
      - Team admins can see and revoke sessions per user
- Added tabs for showing raw AuthKit payload as well as decoded access token